### PR TITLE
Update pruning.py

### DIFF
--- a/pruning.py
+++ b/pruning.py
@@ -51,7 +51,7 @@ print(data_object.num_classes, data_object.insize)
 model = get_model(args.model, 'prune', data_object.num_classes, data_object.insize)
 # state = torch.load(f"checkpoints/{args.model}_{args.dataset}_pretrained.pth")
 # state = torch.load("../resnet152-b121ed2d.pth")
-# model.load_state_dict(state['state_dict'], strict=False)
+# model.load_state_dict(state, strict=False)
 
 ############################### preparing for pruning ###################################
 


### PR DESCRIPTION
Changed 54th line in pruning.py file.
So now, uncommenting the 53rd and 54th line will load the pretrained weights to resnet152 model.
This is in consideration that the weight file (resnet152-b121ed2d.pth) is present in the parent directory of ChipNet.